### PR TITLE
feat: throw RateLimitException on 429 responses

### DIFF
--- a/src/AmznSPAHttp.php
+++ b/src/AmznSPAHttp.php
@@ -15,6 +15,7 @@ use Illuminate\Support\Arr;
 use Jasara\AmznSPA\Constants\JasaraNotes;
 use Jasara\AmznSPA\DataTransferObjects\Schemas\MetadataSchema;
 use Jasara\AmznSPA\Exceptions\AuthenticationException;
+use Jasara\AmznSPA\Exceptions\RateLimitException;
 use Psr\Http\Message\RequestInterface;
 
 class AmznSPAHttp
@@ -105,6 +106,10 @@ class AmznSPAHttp
                     $e->response,
                     $this->config->isPropertySet('authentication_exception_callback') ? $this->config->getAuthenticationExceptionCallback() : null,
                 );
+            }
+
+            if ($e->getCode() === 429) {
+                throw new RateLimitException(previous: $e);   
             }
 
             try {

--- a/src/Exceptions/RateLimitException.php
+++ b/src/Exceptions/RateLimitException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Jasara\AmznSPA\Exceptions;
+
+class RateLimitException extends AmznSPAException
+{
+}

--- a/tests/Unit/AmznSPAHttpTest.php
+++ b/tests/Unit/AmznSPAHttpTest.php
@@ -15,6 +15,7 @@ use Jasara\AmznSPA\DataTransferObjects\Responses\FulfillmentInbound\CreateInboun
 use Jasara\AmznSPA\DataTransferObjects\Responses\FulfillmentInbound\GetAuthorizationCodeResponse;
 use Jasara\AmznSPA\DataTransferObjects\Schemas\Notifications\DestinationResourceSpecificationSchema;
 use Jasara\AmznSPA\Exceptions\AuthenticationException;
+use Jasara\AmznSPA\Exceptions\RateLimitException;
 use Jasara\AmznSPA\Tests\Unit\UnitTestCase;
 
 /**
@@ -273,5 +274,15 @@ class AmznSPAHttpTest extends UnitTestCase
 
         $amzn = new AmznSPA($config);
         $amzn->notifications->getSubscription('ANY_OFFER_CHANGED');
+    }
+
+    public function testRateLimitExceptionIsThrownIfResponseHasCode429()
+    {
+        list($config) = $this->setupConfigWithFakeHttp('errors/rate-limit', 429);
+
+        $this->expectException(RateLimitException::class);
+
+        $amzn = new AmznSPA($config);
+        $amzn->feeds->cancelFeed('some-feed-id');
     }
 }

--- a/tests/stubs/errors/rate-limit.json
+++ b/tests/stubs/errors/rate-limit.json
@@ -1,0 +1,8 @@
+{
+    "errors": [
+        {
+            "message": "You exceeded your quota for the requested resource.",
+            "code": "QuotaExceeded"
+        }
+    ]
+}


### PR DESCRIPTION
Closes #4

Throw a `RateLimitException` when amzn api returns 429 response.