### PR TITLE
Added support for using Assumed Roles for SPA Authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ $config = new AmznSPAConfig(
     lwa_client_secret: '***',
     aws_access_key: '***',
     aws_secret_key: '***',
+    assumed_role_arn: 'arn', // If you would like to authenticate using an assumed role
 );
 ```
 

--- a/src/AmznSPAConfig.php
+++ b/src/AmznSPAConfig.php
@@ -54,6 +54,9 @@ class AmznSPAConfig
         ?CarbonImmutable $grantless_access_token_expires_at = null,
         ?string $restricted_data_token = null,
         ?CarbonImmutable $restricted_data_token_expires_at = null,
+        private ?string $assumed_role_arn = null,
+        public ?array $temporary_credentials = null,
+        public ?CarbonImmutable $temporary_credentials_expire_at = null,
     ) {
         $this->validateStringEnum($marketplace_id, MarketplacesList::allIdentifiers());
 
@@ -111,6 +114,22 @@ class AmznSPAConfig
     public function getApplicationKeys(): ApplicationKeysDTO
     {
         return $this->application_keys;
+    }
+
+    public function setRoleArn(string $assumed_role_arn)
+    {
+        $this->assumed_role_arn = $assumed_role_arn;
+    }
+
+    public function getRoleArn(): string
+    {
+        return $this->assumed_role_arn;
+    }
+
+    public function setTemporaryCredentials(array $credentials)
+    {
+        $this->temporary_credentials_expire_at = CarbonImmutable::parse($credentials["Expiration"]);
+        $this->temporary_credentials = $credentials;
     }
 
     public function getRedirectUrl(): string


### PR DESCRIPTION
Added support for user to set a `role_arn` in config to allow for the use of assumed roles in authentication to the SP-API.