### PR TITLE
fix: add BLOCKED to availability_type validation in delivery window schemas

### DIFF
--- a/src/Data/Schemas/FulfillmentInbound/v20240320/DeliveryWindowOptionSchema.php
+++ b/src/Data/Schemas/FulfillmentInbound/v20240320/DeliveryWindowOptionSchema.php
@@ -10,7 +10,7 @@ use Jasara\AmznSPA\Data\Schemas\BaseSchema;
 class DeliveryWindowOptionSchema extends BaseSchema
 {
     public function __construct(
-        #[RuleValidator(['in:AVAILABLE,CONGESTED'])]
+        #[RuleValidator(['in:AVAILABLE,CONGESTED,BLOCKED'])]
         public string $availability_type,
         #[RuleValidator(['min:36', 'max:38'])]
         public string $delivery_window_option_id,

--- a/src/Data/Schemas/FulfillmentInbound/v20240320/SelectedDeliveryWindowSchema.php
+++ b/src/Data/Schemas/FulfillmentInbound/v20240320/SelectedDeliveryWindowSchema.php
@@ -10,7 +10,7 @@ use Jasara\AmznSPA\Data\Schemas\BaseSchema;
 class SelectedDeliveryWindowSchema extends BaseSchema
 {
     public function __construct(
-        #[RuleValidator(['in:AVAILABLE,CONGESTED'])]
+        #[RuleValidator(['in:AVAILABLE,CONGESTED,BLOCKED'])]
         public string $availability_type,
         #[RuleValidator(['min:36', 'max:38'])]
         public string $delivery_window_option_id,


### PR DESCRIPTION
Amazon's SP-API returns BLOCKED as a valid availability_type value for delivery windows. This fix updates both DeliveryWindowOptionSchema and SelectedDeliveryWindowSchema to accept BLOCKED alongside AVAILABLE and CONGESTED, preventing validation errors when processing delivery window options from Amazon.