### PR TITLE
fix: FulfillmentInbound 2024-03-20 validation constraints

### DIFF
--- a/src/Data/Schemas/FulfillmentInbound/v20240320/DeliveryWindowOptionSchema.php
+++ b/src/Data/Schemas/FulfillmentInbound/v20240320/DeliveryWindowOptionSchema.php
@@ -10,7 +10,7 @@ use Jasara\AmznSPA\Data\Schemas\BaseSchema;
 class DeliveryWindowOptionSchema extends BaseSchema
 {
     public function __construct(
-        #[RuleValidator(['in:AVAILABLE,CONGESTED,BLOCKED'])]
+        #[RuleValidator(['in:AVAILABLE,BLOCKED,CONGESTED,DISCOUNTED'])]
         public string $availability_type,
         #[RuleValidator(['min:36', 'max:38'])]
         public string $delivery_window_option_id,

--- a/src/Data/Schemas/FulfillmentInbound/v20240320/SelectedDeliveryWindowSchema.php
+++ b/src/Data/Schemas/FulfillmentInbound/v20240320/SelectedDeliveryWindowSchema.php
@@ -10,7 +10,7 @@ use Jasara\AmznSPA\Data\Schemas\BaseSchema;
 class SelectedDeliveryWindowSchema extends BaseSchema
 {
     public function __construct(
-        #[RuleValidator(['in:AVAILABLE,CONGESTED,BLOCKED'])]
+        #[RuleValidator(['in:AVAILABLE,BLOCKED,CONGESTED,DISCOUNTED'])]
         public string $availability_type,
         #[RuleValidator(['min:36', 'max:38'])]
         public string $delivery_window_option_id,

--- a/src/Resources/FulfillmentInbound/FulfillmentInbound20240320Resource.php
+++ b/src/Resources/FulfillmentInbound/FulfillmentInbound20240320Resource.php
@@ -358,7 +358,7 @@ class FulfillmentInbound20240320Resource implements ResourceContract
         string $inbound_plan_id,
         #[RuleValidator(['size:38'])]
         string $shipment_id,
-        #[RuleValidator(['size:38'])]
+        #[RuleValidator(['min:36', 'max:38'])]
         string $delivery_window_option_id,
     ): ConfirmDeliveryWindowOptionsResponse|ErrorListResponse {
         $this->validateAttributes(__FUNCTION__, ...func_get_args());


### PR DESCRIPTION
Fixed two validation issues in the FulfillmentInbound API v2024-03-20:

1. Allow 36-character UUIDs for `delivery_window_option_id` in `confirmDeliveryWindowOptions()` - was incorrectly requiring exactly 38 characters, now accepts 36-38 to match schema definition
2. Add missing `DISCOUNTED` value to `availability_type` validation in both `DeliveryWindowOptionSchema` and `SelectedDeliveryWindowSchema`

These changes align the validation rules with Amazon's actual API behavior.