### PR TITLE
chore: update GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:


### PR DESCRIPTION
## Summary
- Update GitHub Actions to versions that support Node.js 24 runtime
- Addresses deprecation warning: Node.js 20 actions will stop working June 2, 2026

## Changes
| Action | Old | New |
|--------|-----|-----|
| actions/checkout | @v4 | @v6 |
| actions/create-github-app-token | @v1 | @v3 |
| docker/build-push-action | @v5 | @v6 |
| docker/login-action | @v3 | @v4 |
| docker/setup-buildx-action | @v3 | @v4 |

## Notes
- `actions/checkout@v6` stores credentials in `$RUNNER_TEMP` instead of `.git/config` (security improvement, no functional change expected)
- `actions/create-github-app-token@v3` removes custom proxy handling (confirmed not in use)

🤖 Generated with [Claude Code](https://claude.com/claude-code)