### PR TITLE
fix: upgrade GitHub Actions for Node.js 24 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: PHPUnit
         run: php -d pcov.enabled=1 -d pcov.directory=. -d pcov.exclude="~vendor~" vendor/bin/phpunit
       - name: Archive code coverage results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: code-coverage-report
           path: tests/resources/clover.xml


### PR DESCRIPTION
Update deprecated Node.js 20 GitHub Actions to versions supporting Node.js 24 runtime, which becomes required in June 2026. Updates actions/upload-artifact to v6.