### PR TITLE
fix: add external_container_identifier fields to BoxSchema

### DIFF
--- a/src/Data/Schemas/FulfillmentInbound/v20240320/BoxSchema.php
+++ b/src/Data/Schemas/FulfillmentInbound/v20240320/BoxSchema.php
@@ -14,6 +14,8 @@ class BoxSchema extends BaseSchema
         public ?BoxContentInformationSource $content_information_source,
         public ?RegionSchema $destination_region,
         public ?DimensionsSchema $dimensions,
+        public ?string $external_container_identifier,
+        public ?string $external_container_identifier_type,
         public ?ItemSchemaList $items,
         #[RuleValidator(['size:38'])]
         public string $package_id,


### PR DESCRIPTION
## Summary

- Add `external_container_identifier` and `external_container_identifier_type` fields to `BoxSchema` in the FulfillmentInbound v20240320 namespace
- Amazon's `listInboundPlanBoxes` API sometimes returns boxes where `box_id` is `null` but `externalContainerIdentifier` (type `AMAZON`) is present
- When both fields are returned, `boxId === externalContainerIdentifier`, making this a reliable fallback for box identification

## Why

Without this field, `externalContainerIdentifier` is silently dropped during deserialization. Application code that needs to route boxes to shipments (via the shipment confirmation ID prefix) has no fallback when `box_id` is null, causing shipment box assignment to fail.

## Test plan

- [ ] Existing tests pass
- [ ] Verify `BoxSchema` correctly deserializes API responses containing `externalContainerIdentifier` with no `boxId`

🤖 Generated with [Claude Code](https://claude.com/claude-code)